### PR TITLE
fix 'Warning: Calling <<-EOS.undent is deprecated!'

### DIFF
--- a/duckdns.rb
+++ b/duckdns.rb
@@ -13,7 +13,7 @@ class Duckdns < Formula
     system "#{bin}/duckdns"
   end
 
-  def plist; <<~EOS.undent
+  def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>
     <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
     <plist version="1.0">


### PR DESCRIPTION
https://github.com/Homebrew/brew/issues/3738