### PR TITLE
read $IP from ~/.duckdns

### DIFF
--- a/duckdns
+++ b/duckdns
@@ -4,6 +4,6 @@ CONFIG_FILE="$HOME/.duckdns"
 
 if [[ -f $CONFIG_FILE ]]; then
   . $CONFIG_FILE
-  echo url="https://www.duckdns.org/update?domains=$DOMAIN&token=$TOKEN&ip=" | \
+  echo url="https://www.duckdns.org/update?domains=$DOMAIN&token=$TOKEN&ip=$IP" | \
     curl -k -o $HOME/.duckdns.log -K -
 fi


### PR DESCRIPTION
This allows hackery like local LAN IP addresses.

I added this line in my ~/.duckdns file: 

`IP=$(ipconfig getifaddr en0)`